### PR TITLE
Move from `optimist` to `yargs` b/c underlying `minimist` security

### DIFF
--- a/bin/sifter.js
+++ b/bin/sifter.js
@@ -19,7 +19,7 @@
 
 var path      = require('path');
 var fs        = require('fs');
-var optimist  = require('optimist');
+var yargs     = require('yargs');
 var cardinal  = require('cardinal');
 var async     = require('async');
 var csv       = require('csv-parse');
@@ -29,7 +29,7 @@ var Sifter    = require('../lib/sifter');
 var highlight = function(obj) { return cardinal.highlight(JSON.stringify(obj)); };
 
 var raw, data, result, t_start, t_end;
-var argv = optimist
+var argv = yargs
 	.usage('Usage: $0 --query="search query" --fields=a,b')
 	.default('direction', 'asc')
 	.default('sort', '')

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "sifter": "./bin/sifter.js"
   },
   "dependencies": {
-    "optimist": "^0.6.1",
-    "cardinal": "^1.0.0",
     "async": "^2.6.0",
+    "cardinal": "^1.0.0",
+    "csv-parse": "^4.6.5",
     "humanize": "^0.0.9",
-    "csv-parse": "^4.6.5"
+    "yargs": "^15.3.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",


### PR DESCRIPTION
vulnerabilities

Problem
-------

`sifter` depends on `optimist` which depends on an old version of
`minimist` which has a security vulnerability
(https://snyk.io/vuln/SNYK-JS-MINIMIST-559764).

Additionally, `optimist` the package is no longer supported.  The
author suggests just using `minimist` directly.  After some
investigation, it looks like `yargs` is basically a drop in replacement
for `optimist`.

Solution
--------

Replace `optimist` with `yargs`.  This removes the vulnerabilty
and requires almost no code changes.

```bash
$ bin/sifter.js --help
Usage: sifter.js --query="search query" --fields=a,b

Options:
  --help       Show help                                               [boolean]
  --version    Show version number                                     [boolean]
  --fields     Search fields (comma separated)                     [default: ""]
  --query      Search query                                        [default: ""]
  --sort       Sort field                                          [default: ""]
  --direction  Sort direction                                   [default: "asc"]
  --file       CSV or JSON dataset

$ bin/sifter.js --version
0.6.0
```